### PR TITLE
Change default UI URL to be HTTPS

### DIFF
--- a/Peaky.Tests/PeakyTestHtmlTests.cs
+++ b/Peaky.Tests/PeakyTestHtmlTests.cs
@@ -34,7 +34,7 @@ namespace Peaky.Tests
 
             var result = response.Content.ReadAsStringAsync().Result;
 
-            result.Should().Contain(@"<script src=""http://itsmonitoringux.azurewebsites.net/its.log.monitoring.js?monitoringVersion=");
+            result.Should().Contain(@"<script src=""https://itsmonitoringux.azurewebsites.net/its.log.monitoring.js?monitoringVersion=");
         }
 
         [Test]

--- a/Peaky/Peaky.nuspec
+++ b/Peaky/Peaky.nuspec
@@ -4,7 +4,7 @@
     <id>Peaky</id>
     <authors>jonsequitur, phillippruett, cynicaloptimist, ckurt</authors>
     <title>Peaky</title>
-    <version>1.10.2-beta</version>
+    <version>1.10.3</version>
     <owners>jonsequitur, phillippruett, cynicaloptimist, ckurt</owners>
     <projectUrl>https://github.com/PhillipPruett/Peaky</projectUrl>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>

--- a/Peaky/TestUiHtmlConfigurationAttribute.cs
+++ b/Peaky/TestUiHtmlConfigurationAttribute.cs
@@ -21,7 +21,7 @@ namespace Peaky
                                             .IfContains("Peaky.TestUiUri")
                                             .And()
                                             .IfTypeIs<string>()
-                                            .Else(() => "http://itsmonitoringux.azurewebsites.net/its.log.monitoring.js"),
+                                            .Else(() => "https://itsmonitoringux.azurewebsites.net/its.log.monitoring.js"),
                         //TODO(phpruett): rehost UI
 
 


### PR DESCRIPTION
When browsing to an http**s** Peaky service, browsers would not retrieve a non secure resource. Changed the UI  URL to be https.
