### PR TITLE
Actually copy to Clipboard

### DIFF
--- a/Peaky.UI/App/peaky.jsx
+++ b/Peaky.UI/App/peaky.jsx
@@ -76,7 +76,17 @@ var Sandwich = React.createClass({
     },
 
     copyToClipboard : function(text) {
-        window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
+        var element = document.createElement('div');
+        element.textContent = text;
+        document.body.appendChild(element);
+
+        var range = document.createRange();
+        range.selectNode(element);
+        window.getSelection().removeAllRanges();
+        window.getSelection().addRange(range);
+
+        document.execCommand('copy');
+        element.remove();
     },
 
     expand: function (testResult) {


### PR DESCRIPTION
It's great in 2016 we can actually [copy to the clipboard](http://caniuse.com/#search=document.execCommand) again. I even used semicolons and 4-space indents just for you.

note: didn't actually test, just taken straight from a module we have in our app so it's straightforward.
