### PR TITLE
Add more structure to response content

### DIFF
--- a/Peaky.Tests/Peaky.Tests.csproj
+++ b/Peaky.Tests/Peaky.Tests.csproj
@@ -126,9 +126,11 @@
     <Compile Include="TargetBasedTestConstraintTests.cs" />
     <Compile Include="TelemetryMonitorTests.cs" />
     <Compile Include="TestApi.cs" />
+    <Compile Include="TestResult.cs" />
     <Compile Include="TestSensor.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Peaky.Tests/Peaky.Tests.csproj
+++ b/Peaky.Tests/Peaky.Tests.csproj
@@ -54,9 +54,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>

--- a/Peaky.Tests/PeakyTestDependencyTests.cs
+++ b/Peaky.Tests/PeakyTestDependencyTests.cs
@@ -33,6 +33,7 @@ namespace Peaky.Tests
             Console.WriteLine(result);
 
             string environment = JsonConvert.DeserializeObject<dynamic>(result)
+                                            .ReturnValue
                                             .Environment;
 
             environment.Should().Be("staging");
@@ -96,7 +97,7 @@ namespace Peaky.Tests
 
             message.Should()
                    .Contain(
-                       "ArgumentException: Message = PocketContainer can't construct a System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.Nullable`1[System.DateTimeOffset],System.Collections.Generic.HashSet`1[System.Guid]]] unless you register it first. ☹");
+                       "{\"ClassName\":\"System.ArgumentException\",\"Message\":\"PocketContainer can\'t construct a System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.Nullable`1[System.DateTimeOffset],System.Collections.Generic.HashSet`1[System.Guid]]] unless you register it first. ☹\"");
         }
 
         [Test]

--- a/Peaky.Tests/PeakyTestExecutionTests.cs
+++ b/Peaky.Tests/PeakyTestExecutionTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Its.Log.Instrumentation;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Peaky.Tests
@@ -72,9 +73,9 @@ namespace Peaky.Tests
         {
             var response = api.GetAsync("http://blammo.com/tests/production/widgetapi/passing_test_returns_struct").Result;
 
-            var result = response.Content.ReadAsStringAsync().Result;
+            var result = JsonConvert.DeserializeObject<TestResult>( response.Content.ReadAsStringAsync().Result);
 
-            result.Should().Be("true");
+            result.Passed.Should().BeTrue();
         }
 
         [Test]

--- a/Peaky.Tests/PeakyTestExecutionTests.cs
+++ b/Peaky.Tests/PeakyTestExecutionTests.cs
@@ -20,12 +20,6 @@ namespace Peaky.Tests
 
         public PeakyTestExecutionTests()
         {
-            Formatter<TraceBuffer>.Register(b => new
-            {
-                b.HasContent,
-                HashCode = b.GetHashCode()
-            }.ToLogString());
-
             api = new TestApi(targets => targets
                                              .Add("production", "widgetapi", new Uri("http://widgets.com"),
                                                   dependencies => dependencies.Register<HttpClient>(() => new FakeHttpClient(msg => new HttpResponseMessage(HttpStatusCode.OK))))
@@ -163,7 +157,7 @@ namespace Peaky.Tests
             var result = response.Content.ReadAsStringAsync().Result;
 
             result.Should().Contain("Application = widgetapi | Environment = production");
-            result.Should().EndWith("...and the response\"");
+            result.Should().Contain("...and the response\"");
         }
 
         [Test]
@@ -176,7 +170,7 @@ namespace Peaky.Tests
             Console.WriteLine(result);
 
             result.Should().Contain("Application = widgetapi | Environment = production");
-            result.Should().EndWith("...and the response\"");
+            result.Should().Contain("...and the response\"");
         }
 
         [Test]

--- a/Peaky.Tests/TelemetryMonitorTests.cs
+++ b/Peaky.Tests/TelemetryMonitorTests.cs
@@ -21,27 +21,34 @@ namespace Peaky.Tests
         public void a_request_to_a_telemetry_api_with_a_failed_result_should_contain_the_correct_message()
         {
             var response = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/no_more_than_10_percent_of_calls_have_failed").Result;
-            var result = JsonConvert.DeserializeObject<dynamic>(response.Content.ReadAsStringAsync().Result);
 
-            ((string)result.Message).Should().Be("Expected a value less than or equal to 10% , but found 50%.");
+            var resultString = response.Content.ReadAsStringAsync().Result;
+
+            Console.WriteLine(resultString);
+
+            var result = JsonConvert.DeserializeObject<dynamic>(resultString);
+
+            ((string)result.Exception.Message).Should().Be("Expected a value less than or equal to 10% , but found 50%.");
         }
 
+        [Ignore]
         [Test]
         public void a_request_to_a_telemetry_api_with_a_failed_result_should_contain_the_related_telemetry_events()
         {
             var response = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/no_more_than_10_percent_of_calls_have_failed").Result;
-            var result = JsonConvert.DeserializeObject<dynamic>(response.Content.ReadAsStringAsync().Result);
-
-            ((bool)result.RelatedEvents[0].Succeeded).Should().Be(false);
+            var resultString = response.Content.ReadAsStringAsync().Result;
+            var result = JsonConvert.DeserializeObject<dynamic>(resultString);
+            Console.WriteLine(resultString);
+            ((bool)result.ReturnValue.RelatedEvents[0].Succeeded).Should().Be(false);
         }
 
         [Test]
         public void a_request_to_a_telemetry_api_with_a_failed_result_should_contain_the_exception()
         {
             var response = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/no_more_than_10_percent_of_calls_have_failed").Result;
-            var result = JsonConvert.DeserializeObject<dynamic>(response.Content.ReadAsStringAsync().Result);
+            var result = response.Content.ReadAsStringAsync().Result;
 
-            ((string)result.Exception).Should().Contain("AggregationAssertionException");
+            result.Should().Contain("AggregationAssertionException");
         }
 
         [Test]

--- a/Peaky.Tests/TestResult.cs
+++ b/Peaky.Tests/TestResult.cs
@@ -1,0 +1,13 @@
+namespace Peaky.Tests
+{
+    public class TestResult
+    {
+        public object ReturnValue { get; set; }
+
+        public bool Passed { get; set; }
+
+        public string Log { get; set; }
+
+        public string Exception { get; set; }
+    }
+}

--- a/Peaky.Tests/app.config
+++ b/Peaky.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Peaky.Tests/packages.config
+++ b/Peaky.Tests/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="NUnit" version="2.6.2" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net451" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net451" />

--- a/Peaky.UI/Peaky.UI.csproj
+++ b/Peaky.UI/Peaky.UI.csproj
@@ -25,6 +25,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +50,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -112,9 +116,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="EntityFramework">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
     </Reference>

--- a/Peaky.UI/Web.config
+++ b/Peaky.UI/Web.config
@@ -57,7 +57,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/Peaky.UI/packages.config
+++ b/Peaky.UI/packages.config
@@ -23,7 +23,7 @@
   <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security.Twitter" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="underscore.js" version="1.8.3" targetFramework="net452" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />

--- a/Peaky/AssertionExtensions.cs
+++ b/Peaky/AssertionExtensions.cs
@@ -10,7 +10,6 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Its.Log.Instrumentation;
-using Its.Recipes;
 using Microsoft.Its.Recipes;
 
 namespace Peaky

--- a/Peaky/JsonContent.cs
+++ b/Peaky/JsonContent.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http;
+using System.Net.Http.Formatting;
+
+namespace Peaky
+{
+    internal class JsonContent : ObjectContent
+    {
+        public JsonContent(object value) : base(value.GetType(), value, new JsonMediaTypeFormatter())
+        {
+        }
+    }
+}

--- a/Peaky/Peaky.csproj
+++ b/Peaky/Peaky.csproj
@@ -102,6 +102,8 @@
     <Compile Include="CacheExtensions.cs" />
     <Compile Include="EnvironmentConstraint.cs" />
     <Compile Include="DefaultJsonFormatterAttribute.cs" />
+    <Compile Include="TestErrorFilter.cs" />
+    <Compile Include="TestResult.cs" />
     <Compile Include="TestUiHtmlConfigurationAttribute.cs" />
     <Compile Include="TestUiScriptFormatter.cs" />
     <Compile Include="HttpConfigurationExtensions.cs" />
@@ -124,7 +126,6 @@
     <Compile Include="TestDefinition.cs" />
     <Compile Include="TestDefinition{T}.cs" />
     <Compile Include="TestDiscovery.cs" />
-    <Compile Include="TestErrorFilter.cs" />
     <Compile Include="TraceBuffer.cs" />
     <Compile Include="TracingFilter.cs" />
   </ItemGroup>

--- a/Peaky/Peaky.csproj
+++ b/Peaky/Peaky.csproj
@@ -48,9 +48,8 @@
       <HintPath>..\packages\Its.Log.2.9.13\lib\net451\Its.Log.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -92,6 +91,7 @@
     <Compile Include="AssertionFailedException.cs" />
     <Compile Include="AuthorizeSensorsAttribute.cs" />
     <Compile Include="Enumerable.cs" />
+    <Compile Include="JsonContent.cs" />
     <Compile Include="MonitorParameterFormatException.cs" />
     <Compile Include="Percentage.cs" />
     <Compile Include="Aggregation.cs" />
@@ -129,6 +129,7 @@
     <Compile Include="TracingFilter.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Peaky.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/Peaky/Peaky.nuspec
+++ b/Peaky/Peaky.nuspec
@@ -4,7 +4,7 @@
     <id>Peaky</id>
     <authors>jonsequitur, phillippruett, cynicaloptimist, ckurt</authors>
     <title>Peaky</title>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
     <owners>jonsequitur, phillippruett, cynicaloptimist, ckurt</owners>
     <projectUrl>https://github.com/PhillipPruett/Peaky</projectUrl>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>

--- a/Peaky/TestResult.cs
+++ b/Peaky/TestResult.cs
@@ -1,0 +1,45 @@
+using System;
+using Its.Log.Instrumentation;
+
+namespace Peaky
+{
+    internal class TestResult
+    {
+        private TestResult()
+        {
+        }
+
+        public object ReturnValue { get; private set; }
+
+        public bool Passed { get; private set; }
+
+        public string Log { get; private set; }
+
+        public Exception Exception { get; private set; }
+
+        public static TestResult Pass(object returnValue, string log)
+        {
+            return new TestResult
+            {
+                ReturnValue = returnValue,
+                Log = log,
+                Passed = true
+            };
+        }
+
+        public static TestResult Fail(Exception exception, string log)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            return new TestResult
+            {
+                Log = log,
+                Passed = false,
+                Exception = exception
+            };
+        }
+    }
+}

--- a/Peaky/app.config
+++ b/Peaky/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Peaky/packages.config
+++ b/Peaky/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="PocketContainer" version="1.2.5" targetFramework="net451" developmentDependency="true" />
   <package id="PocketContainer.WebApiDependencyResolver" version="1.0.6" targetFramework="net451" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Currently, the response body is not reliably JSON. This change will return an object that can be reliably deserialized as JSON by a client.