### PR TITLE
ILogger support

### DIFF
--- a/Peaky.Tests/PeakyTestDependencyTests.cs
+++ b/Peaky.Tests/PeakyTestDependencyTests.cs
@@ -139,7 +139,7 @@ namespace Peaky.Tests
         [Fact]
         public void When_HttpClient_BaseAddress_is_set_in_dependency_registration_then_it_is_not_overridden()
         {
-            var api = new PeakyService(configureTargets: targets =>
+            var api = new PeakyService(targets =>
                                            targets
                                                .Add("production", "widgetapi", new Uri("http://google.com"),
                                                     dependencies => dependencies.Register(() => new HttpClient
@@ -161,7 +161,7 @@ namespace Peaky.Tests
         [Fact]
         public void When_HttpClient_BaseAddress_is_not_set_in_dependency_registration_then_it_is_set_to_the_test_target_configured_value()
         {
-            var api = new PeakyService(configureTargets: targets =>
+            var api = new PeakyService(targets =>
                                            targets
                                                .Add("production", "widgetapi", new Uri("http://bing.com"),
                                                     dependencies => dependencies.Register(() => new HttpClient())));

--- a/Peaky.Tests/TestLoggingTests.cs
+++ b/Peaky.Tests/TestLoggingTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Pocket;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Peaky.Tests
+{
+    public class TestLoggingTests
+    {
+        private readonly HttpClient apiClient;
+
+        private readonly CompositeDisposable disposables = new CompositeDisposable();
+
+        public TestLoggingTests(ITestOutputHelper output)
+        {
+            disposables.Add(LogEvents.Subscribe(e => output.WriteLine(e.ToLogString())));
+
+            var peakyService = new PeakyService(
+                targets => targets
+                    .Add("production",
+                         "widgetapi",
+                         new Uri("http://widgets.com"),
+                         dependencies => dependencies.Register<HttpClient>(() =>
+                         {
+                             return new FakeHttpClient(msg => new HttpResponseMessage(HttpStatusCode.OK));
+                         }))
+                    .Add("staging",
+                         "widgetapi",
+                         new Uri("http://widgets.com"),
+                         dependencies => dependencies.Register<HttpClient>(() =>
+                         {
+                             return new FakeHttpClient(msg => new HttpResponseMessage(HttpStatusCode.OK));
+                         })));
+
+            disposables.Add(peakyService);
+
+            apiClient = peakyService.CreateHttpClient();
+
+            TestsWithTraceOutput.GetResponse = () => "...and the response";
+        }
+
+        public void Dispose()
+        {
+            disposables.Dispose();
+            TestsWithTraceOutput.Barrier = null;
+        }
+
+        [Fact]
+        public void When_a_test_passes_then_the_response_contains_trace_output_written_by_the_test()
+        {
+            var response = apiClient.GetAsync("http://blammo.com/tests/production/widgetapi/write_to_trace").Result;
+
+            var result = response.Content.ReadAsStringAsync().Result;
+
+            result.Should().Contain("Application = widgetapi | Environment = production");
+            result.Should().Contain("...and the response\"");
+        }
+
+        [Fact]
+        public void When_a_test_passes_then_the_response_contains_ILogger_output_written_by_the_test()
+        {
+            var response = apiClient.GetAsync("http://blammo.com/tests/production/widgetapi/write_to_logger").Result;
+
+            var result = response.Content.ReadAsStringAsync().Result;
+
+            result.Should().Contain("Application = widgetapi | Environment = production");
+            result.Should().Contain("...and the response\"");
+        }
+
+        [Fact]
+        public async Task When_a_test_passes_then_the_response_does_not_contains_trace_output_written_by_other_tests()
+        {
+            TestsWithTraceOutput.Barrier = new Barrier(2);
+
+            var productionResponse = apiClient.GetAsync("http://blammo.com/tests/production/widgetapi/write_to_trace");
+            var stagingResponse = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/write_to_trace");
+
+            var productionResult = await productionResponse.Result.Content.ReadAsStringAsync();
+            var stagingResult = await stagingResponse.Result.Content.ReadAsStringAsync();
+
+            productionResult.Should().Contain("Environment = production");
+            productionResult.Should().NotContain("Environment = staging");
+            stagingResult.Should().Contain("Environment = staging");
+            stagingResult.Should().NotContain("Environment = production");
+        }
+
+        [Fact]
+        public async Task When_a_test_passes_then_the_response_does_not_contain_ILogger_output_written_by_other_tests()
+        {
+            TestsWithTraceOutput.Barrier = new Barrier(2);
+
+            var productionResponse = apiClient.GetAsync("http://blammo.com/tests/production/widgetapi/write_to_logger");
+            var stagingResponse = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/write_to_logger");
+
+            var productionResult = await productionResponse.Result.Content.ReadAsStringAsync();
+            var stagingResult = await stagingResponse.Result.Content.ReadAsStringAsync();
+
+            productionResult.Should().Contain("Environment = production");
+            productionResult.Should().NotContain("Environment = staging");
+            stagingResult.Should().Contain("Environment = staging");
+            stagingResult.Should().NotContain("Environment = production");
+        }
+
+        [Fact]
+        public async Task When_a_test_fails_then_the_response_contains_trace_output_written_by_the_test()
+        {
+            TestsWithTraceOutput.GetResponse = () => throw new Exception("Doh!");
+
+            var response = await apiClient.GetAsync("http://blammo.com/tests/production/widgetapi/write_to_trace");
+
+            var result = await response.AsTestResult();
+
+            result.Log.Should().Contain("Application = widgetapi | Environment = production");
+        }
+
+        [Fact]
+        public async Task When_a_test_fails_then_the_response_contains_ILogger_output_written_by_the_test()
+        {
+            TestsWithTraceOutput.GetResponse = () => throw new Exception("oops!");
+
+            var response = await apiClient.GetAsync("http://blammo.com/tests/production/widgetapi/write_to_logger");
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            result.Should().Contain("Application = widgetapi | Environment = production");
+        }
+
+        [Fact]
+        public async Task When_a_test_fails_then_the_response_does_not_contains_trace_output_written_by_other_tests()
+        {
+            TestsWithTraceOutput.Barrier = new Barrier(2);
+            TestsWithTraceOutput.GetResponse = () => throw new Exception("oh noes!");
+
+            var productionResponse = apiClient.GetAsync("http://blammo.com/tests/production/widgetapi/write_to_trace");
+            var stagingResponse = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/write_to_trace");
+
+            var productionResult = await productionResponse.Result.Content.ReadAsStringAsync();
+            var stagingResult = await stagingResponse.Result.Content.ReadAsStringAsync();
+
+            productionResult.Should().Contain("Environment = production");
+            productionResult.Should().NotContain("Environment = staging");
+            stagingResult.Should().Contain("Environment = staging");
+            stagingResult.Should().NotContain("Environment = production");
+            productionResult.Should().Contain("oh noes!");
+            stagingResult.Should().Contain("oh noes!");
+        }
+
+        [Fact]
+        public async Task When_a_test_fails_then_the_response_does_not_contain_ILogger_output_written_by_other_tests()
+        {
+            TestsWithTraceOutput.Barrier = new Barrier(2);
+            TestsWithTraceOutput.GetResponse = () => throw new Exception("oh noes!");
+
+            var productionResponse = apiClient.GetAsync("http://blammo.com/tests/production/widgetapi/write_to_logger");
+            var stagingResponse = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/write_to_logger");
+
+            var productionResult = await productionResponse.Result.Content.ReadAsStringAsync();
+            var stagingResult = await stagingResponse.Result.Content.ReadAsStringAsync();
+
+            productionResult.Should().Contain("Environment = production");
+            productionResult.Should().NotContain("Environment = staging");
+            stagingResult.Should().Contain("Environment = staging");
+            stagingResult.Should().NotContain("Environment = production");
+            productionResult.Should().Contain("oh noes!");
+            stagingResult.Should().Contain("oh noes!");
+        }
+    }
+
+    public class TestsWithTraceOutput : IPeakyTest
+    {
+        public static Barrier Barrier;
+
+        public static Func<dynamic> GetResponse;
+
+        private readonly TestTarget target;
+
+        public TestsWithTraceOutput(TestTarget target) => this.target = target;
+
+        public async Task<dynamic> write_to_trace()
+        {
+            if (Barrier != null)
+            {
+                await Task.Yield();
+                Barrier.SignalAndWait(TimeSpan.FromSeconds(2));
+            }
+
+            Trace.WriteLine($"Application = {target.Application} | Environment = {target.Environment}");
+
+            return GetResponse();
+        }
+    }
+
+    public class TestsWithLoggeOutput : IPeakyTest
+    {
+        public static Barrier Barrier;
+
+        public static Func<dynamic> GetResponse;
+
+        private readonly TestTarget target;
+        private readonly ILogger logger;
+
+        public TestsWithLoggeOutput(TestTarget target, ILogger logger)
+        {
+            this.target = target;
+            this.logger = logger;
+        }
+
+        public async Task<dynamic> write_to_logger()
+        {
+            if (Barrier != null)
+            {
+                await Task.Yield();
+                Barrier.SignalAndWait(TimeSpan.FromSeconds(2));
+            }
+
+            Trace.WriteLine($"Application = {target.Application} | Environment = {target.Environment}");
+
+            return GetResponse();
+        }
+    }
+}

--- a/Peaky/ApplicationBuilderExtensions.cs
+++ b/Peaky/ApplicationBuilderExtensions.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Peaky
 {
@@ -45,6 +46,9 @@ namespace Peaky
                     var testRouter = new TestRouter(testTargets, testDefinitions)
                         .AllowVerbs("GET", "POST");
                     builder.Routes.Add(testRouter);
+
+                    services.GetService<ILoggerFactory>()
+                            ?.AddProvider(new PeakyLoggerProvider());
                 }
             });
 

--- a/Peaky/Peaky.csproj
+++ b/Peaky/Peaky.csproj
@@ -24,6 +24,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="pocket.disposable" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Pocket.TypeDiscovery" Version="0.3.13">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Peaky/PeakyLogger.cs
+++ b/Peaky/PeakyLogger.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Pocket;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Peaky
+{
+    internal class PeakyLogger : ILogger
+    {
+        private readonly string categoryName;
+
+        public PeakyLogger(string categoryName)
+        {
+            this.categoryName = categoryName;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) =>
+            TraceBuffer.Current?.Write(formatter(state, exception));
+
+        public bool IsEnabled(LogLevel logLevel) =>
+            TraceBuffer.Current != null;
+
+        public IDisposable BeginScope<TState>(TState state) =>
+            Disposable.Empty;
+    }
+}

--- a/Peaky/PeakyLoggerProvider.cs
+++ b/Peaky/PeakyLoggerProvider.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+namespace Peaky
+{
+    internal class PeakyLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) =>
+            new PeakyLogger(categoryName);
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Peaky/ServiceCollectionExtensions.cs
+++ b/Peaky/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/Peaky/ServiceCollectionExtensions.cs
+++ b/Peaky/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Peaky
         {
             builder.TryAddSingleton(c =>
             {
-                var registry = new TestTargetRegistry();
+                var registry = new TestTargetRegistry(c);
 
                 configure?.Invoke(registry);
 

--- a/Peaky/TestDefinition{T}.cs
+++ b/Peaky/TestDefinition{T}.cs
@@ -15,7 +15,7 @@ using static Pocket.Logger<Peaky.TestDefinition>;
 namespace Peaky
 {
     internal class TestDefinition<T> : TestDefinition
-        where T : class, IPeakyTest
+        where T : IPeakyTest
     {
         private readonly Func<T, dynamic> defaultExecuteTestMethod;
         private readonly MethodInfo methodInfo;

--- a/Sample/Peaky.SampleWebApplication/HomePageTests.cs
+++ b/Sample/Peaky.SampleWebApplication/HomePageTests.cs
@@ -10,6 +10,7 @@ namespace Peaky.SampleWebApplication
     public class HomePageTests : IHaveTags
     {
         private readonly HttpClient httpClient;
+        private ILogger<HomePageTests> logger;
 
         public HomePageTests(
             HttpClient httpClient,
@@ -19,17 +20,25 @@ namespace Peaky.SampleWebApplication
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
+
+            this.logger = loggerFactory.CreateLogger<HomePageTests>();
             this.httpClient = httpClient;
         }
 
         public string[] Tags => new[]
-                                {
-                                    "NonSideEffecting"
-                                };
+        {
+            "NonSideEffecting"
+        };
 
         public async Task homepage_should_return_200OK()
         {
-            (await httpClient.GetAsync("/")).StatusCode.Should().Be(HttpStatusCode.OK);
+            var response = await httpClient.GetAsync("/");
+
+            logger.LogInformation("Response: {response}", response);
+
+            response.StatusCode
+                    .Should()
+                    .Be(HttpStatusCode.OK);
         }
     }
 }

--- a/Sample/Peaky.SampleWebApplication/HomePageTests.cs
+++ b/Sample/Peaky.SampleWebApplication/HomePageTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 
 namespace Peaky.SampleWebApplication
 {
@@ -9,8 +11,14 @@ namespace Peaky.SampleWebApplication
     {
         private readonly HttpClient httpClient;
 
-        public HomePageTests(HttpClient httpClient)
+        public HomePageTests(
+            HttpClient httpClient,
+            ILoggerFactory loggerFactory)
         {
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
             this.httpClient = httpClient;
         }
 


### PR DESCRIPTION
This adds support for dependency-injecting anything that's registered with the ASP.NET Core DI container.

It also registers a Peaky `ILoggerProvider` so that if your Peaky tests declare a dependency on `ILoggerFactory`, you can call `CreateLogger` to get a logger that will log to the test output and appear in the test result's Log field.