### PR TITLE
Enable HTTPS to override in test urls

### DIFF
--- a/Peaky.Tests/PeakyService.cs
+++ b/Peaky.Tests/PeakyService.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Pocket;
+using Pocket.For.MicrosoftExtensionsLogging;
 
 namespace Peaky.Tests;
 
@@ -79,7 +80,7 @@ public class PeakyService : IDisposable
             IApplicationBuilder app,
             ILoggerFactory loggerFactory)
         {
-            // FIX: (Configure)     loggerFactory.AddPocketLogger();
+            loggerFactory.AddPocketLogger();
 
             app.UseMvc();
 

--- a/Peaky.Tests/TestDiscoveryTests.cs
+++ b/Peaky.Tests/TestDiscoveryTests.cs
@@ -21,7 +21,7 @@ namespace Peaky.Tests;
 public class TestDiscoveryTests : IDisposable
 {
     private readonly HttpClient apiClient;
-    private readonly CompositeDisposable disposables = new CompositeDisposable();
+    private readonly CompositeDisposable disposables = new();
 
     public TestDiscoveryTests(ITestOutputHelper output)
     {
@@ -587,5 +587,21 @@ public class TestDiscoveryTests : IDisposable
         var content = JsonConvert.DeserializeObject<TestDiscoveryResponse>(await response.Content.ReadAsStringAsync());
         content.Tests.Should().Contain(t => t.Url.ToString().EndsWith("I_do_stuff_and_return_task?expectedResult=false&testCaseId=case8", StringComparison.OrdinalIgnoreCase));
         content.Tests.Should().Contain(t => t.Url.ToString().EndsWith("I_do_stuff_and_return_task_of_bool?expectedResult=false&testCaseId=case9", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Tests_URL_scheme_can_be_configured_to_differ_from_the_default()
+    {
+        using var peakyService = new PeakyService(
+            targets =>
+                targets.Add("production", "example", new Uri("https://example.com")));
+
+        var apiClient = peakyService.CreateHttpClient();
+
+        var response = await apiClient.GetAsync("http://example.com/tests");
+
+        var content = JsonConvert.DeserializeObject<TestDiscoveryResponse>(await response.Content.ReadAsStringAsync());
+
+        content.Tests.Should().Contain(o => o.Url == "https://example.com/tests/production/example/passing_test_returns_object");
     }
 }

--- a/Peaky/HttpRequestExtensions.cs
+++ b/Peaky/HttpRequestExtensions.cs
@@ -15,11 +15,17 @@ internal static class HttpRequestExtensions
         TestTarget testTarget,
         TestDefinition testDefinition)
     {
-        var scheme = request.Scheme;
+        var scheme = testTarget.BaseAddress.Scheme switch
+        {
+            "https" => "https",
+            _ => request.Scheme
+        };
+
         var host = request.Host;
 
         return $"{scheme}://{host}/tests/{testTarget.Environment}/{testTarget.Application}/{testDefinition.TestName}";
     }
+
     internal static string GetLinkWithQuery(
         this HttpRequest request,
         TestTarget testTarget,
@@ -41,7 +47,6 @@ internal static class HttpRequestExtensions
         query = string.IsNullOrWhiteSpace(query) ? string.Empty : $"?{query}";
         return $"{request.GetLink(testTarget, testDefinition)}{query}";
     }
-
 
     internal static string GetQueryString(IEnumerable<Parameter> parameters)
     {

--- a/Peaky/TestTargetRegistry.cs
+++ b/Peaky/TestTargetRegistry.cs
@@ -66,7 +66,7 @@ public class TestTargetRegistry : IEnumerable<TestTarget>
         container.OnFailedResolve = (t, e) =>
             throw new InvalidOperationException($"TestTarget does not contain registration for '{t}'.");
 
-        if (services != null)
+        if (services is not null)
         {
             // fall back to application's IServiceProvider
             container.AddStrategy(type =>


### PR DESCRIPTION
Previously, Peaky tests assigned their URIs using the URI scheme of the incoming requests, so that the same configuration would be valid whether the hosting service was exposed via HTTP or HTTPS. This doesn't work for reverse proxies since the outward-facing URI could be HTTPS but the hosted service receives a proxied HTTP request.

The current change allows for tests defined with `https://` URIs to be advertised with `https://` URIs even when the service sees incoming `http://` requests.